### PR TITLE
re-wrote upload usage calculation logic

### DIFF
--- a/qb_upload_limit_per_day.py
+++ b/qb_upload_limit_per_day.py
@@ -8,10 +8,10 @@ from os.path import exists
 
 # Configuration
 UPLOAD_LIMIT = 50  # Upload limit in GB (per day)
-QB_URL = "http://localhost:8080" # qBittorrent Web UI URL
+QB_URL = "http://localhost:8080"  # qBittorrent Web UI URL
 CHECK_INTERVAL = 10  # In seconds
 RESET_TIME = "00:01"  # HH:MM ("00:01" will reset exactly at 12:01.AM)
-AUTH_ENABLED = True
+AUTH_ENABLED = False
 TIMEOUT = 10
 
 # Global vars
@@ -123,7 +123,7 @@ def pause_all_seeding_torrents():
             print("Daily upload data usage limit reached, all seeding torrents paused")
         return True
     except:
-        return False # qBittorrent is offline
+        return False  # qBittorrent is offline
 
 
 def resume_all_paused_torrents():
@@ -143,7 +143,7 @@ def load_data_from_cache():
         with open("qb_upload_data_usage_cache.json", "r") as file:
             return json.load(file)
     except:
-        print("can't load data from cache")
+        print("can't load data from cache, so creating one...")
         data = []
         save_data_to_cache(data)
         return data


### PR DESCRIPTION
This MR improves the accuracy of daily upload calculation:

1. The global upload statistics is used instead of the session one. This allows to track the data accurately, regardless if the script was restarted while qbittorrent is running or if a user restarted the qbittorrent session. 
With the global statitistics, it's only important that the script is running around the midnight. After day, we can calculate the usage as total_upload - total_upload_at_midnight and qBittorrent does the rest for us.
2. If the reset task can't complete due to the server being unreachable, it will retry, instead of failing. In the current implementation, if the server was down at 00:01, the upload is not reset until the user does it manually.
3. The default update time is increased to 60 seconds, as global statistics is updated less often than the session one.