### PR TITLE
Add ini-based config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,22 @@
 
 A Python script that automatically runs in the background on startup to track qBittorrent's upload data usage. It pauses all seeding torrents if the upload limit is reached. The script resets at 12:01 AM daily and resumes all torrents.
 
-## Setup
+## Running the script
+
+The script requires Python 3.8+ to run. You can use [pyenv](https://github.com/pyenv/pyenv) in case you can't install a higher Python version system-wide.
+
+The script requires qBittorrent WebUI to be activated: Tools -> Options -> Web UI -> Enable "Web User Interface (Remote Control)"
+
+1. Install the libraries with `pip install -r requirements.txt`
+2. Run `python python qb_upload_limit_per_day.py`
+
+In case you want to run the script on Linux unattended, you can use `nohup`:
+
+`nohup python -u qb_upload_limit_per_day.py >> run.log 2>&1 `
+
+This will allow the script to keep running even after a shell was killed. `stdout` and `stderr` are redirected to `run.log`. 
+
+## Setup for Windows scheduler
 
 1. Download the [qb_upload_limit_per_day.py](https://github.com/Tetrax-10/qBittorrent-upload-limit-per-day/blob/main/qb_upload_limit_per_day.py) script.
 2. Place it inside **`C:\qBittorrent-upload-limit-per-day`** folder.
@@ -20,17 +35,44 @@ To check if the script has been installed and working properly, go to `C:\qBitto
 
 This script does work on Linux and Mac. But the Task scheduler (Xml) is limited to Windows only.
 
-## Authentification
+## Authentication 
 
-In order to allow the script to connect to servers that require authentification, you need to:
-1. Change `AUTH_ENABLED` in `qb_upload_limit_per_day.py` to `True`.
-2. Create `secrets.json` in the same folder as the script.
-3. Add your username and password to `secrets.json` in the following format:
-```json
-{
-    "username" : "<your username>",
-    "password" : "<your password>"
-}
+In order to allow the script to connect to servers that require authentication, you need to change the `[AUTH]` section of `config.conf`:
+```ini
+[AUTH]
+username = <your username>
+password = <your password>
+```
+
+## Config parameters
+The config parameters are stored in `config.conf`.
+
+Settings section:
+- `upload_limit` - maximum number of data in GBs that can be uploaded per day. (Default: `50` Gb) 
+- `qb_url` - qBittorent Web UI URL (Default: `http://localhost:8080`)
+- `check_interval` - how often the script checks upload usage, in seconds. It is not recommended to set to lower than 60 seconds, as qBittorrent doesn't update its statistics often (Default: `60` s) 
+- `reset_time` - time when the daily usage is reset. The format is HH:MM (Default: `00:01`)
+authentication for clients on localhost" (Default: `false`)
+- `timeout` - when requests to WebUI timeout, in s. Raise it if the connection to the qBittorrent server is slow (Default: `10` s)
+
+Auth section:
+- `username` - a username used for authentication (blank for no authentication) (Default: blank)
+- `password` - a password used for authentication (blank for no authentication) (Default: blank)
+
+
+Default config:
+
+```ini
+[SETTINGS]
+upload_limit = 50
+qb_url = http://localhost:8080
+check_interval = 60
+reset_time = 00:01
+timeout = 10
+
+[AUTH]
+username = 
+password = 
 ```
 
 ## To do

--- a/config.conf
+++ b/config.conf
@@ -1,0 +1,16 @@
+[SETTINGS]
+# Upload limit in GB (per day)
+upload_limit = 50
+# qBittorrent Web UI URL
+qb_url = http://localhost:8080
+# In seconds
+check_interval = 10
+# HH:MM ("00:01" will reset exactly at 12:01.AM)
+reset_time = 00:01
+# In seconds
+timeout = 10
+
+[AUTH]
+username = 
+password = 
+

--- a/qb_upload_limit_per_day.py
+++ b/qb_upload_limit_per_day.py
@@ -3,16 +3,16 @@ import json
 import time
 import datetime
 import schedule
+import configparser
 
 from os.path import exists
 
-# Configuration
-UPLOAD_LIMIT = 50  # Upload limit in GB (per day)
-QB_URL = "http://localhost:8080"  # qBittorrent Web UI URL
-CHECK_INTERVAL = 10  # In seconds
-RESET_TIME = "00:01"  # HH:MM ("00:01" will reset exactly at 12:01.AM)
-AUTH_ENABLED = False
-TIMEOUT = 10
+# Configuration parameters
+UPLOAD_LIMIT = None
+QB_URL = None
+CHECK_INTERVAL = None
+RESET_TIME = None
+TIMEOUT = None
 
 PAUSED_TORRENT_SAVE_FILE = "qb_torrents.json"
 # Global vars
@@ -21,75 +21,69 @@ initial_upload_data_today = None
 update_job = None
 reset_job = None
 
+password = None
+username = None
+cookies = None
 
 def login():
     """
-    Performs login to qBittorrent WebUI using data from secrets.json
+    Performs login to qBittorrent WebUI using data from config.conf
     If login is successful, the resulting cookies are stored in 
     cookies.json file, so that the other methods can access them 
-    for authentification
+    for authentication
     """
-    file_name = "secrets.json"
-    if not exists(file_name):
-        return False, f"{file_name} with your username and password doesn't exist."
+    global cookies
     try:
-        with open(file_name) as f:
-            secrets = json.load(f)
-            if "username" not in secrets:
-                return False, f"username field is not in {file_name}"
-            if "password" not in secrets:
-                return False, f"password field is not in {file_name}"
+        response = requests.post(f"{QB_URL}/api/v2/auth/login",data={"username":username,"password":password})
+        if response.status_code != 200:
+            return False, response.text
+        if not response.text.lower().startswith("ok"):
+            return False, "Wrong username or password"
+        
+        cookies = response.cookies.get_dict()
+        with open("cookies.json","w") as f:
+            json.dump(cookies, f)
     except Exception as e:
-        return False, f"Error {e} occured while reading JSON"
-
-    response = requests.post(f"{QB_URL}/api/v2/auth/login",data={"username":secrets["username"],"password":secrets["password"]})
-    if response.status_code != 200:
-        return False, response.text
-    if not response.text.lower().startswith("ok"):
-        return False, "Wrong username or password"
-    
-    with open("cookies.json","w") as f:
-        json.dump(response.cookies.get_dict(), f)
-    
+        return False, str(e)
     return True, ""
 
 
 def print_login_failure(login_res):
     """
-    Prints the reason the login failed and a template for secrets.json
+    Prints the reason the login failed and a template for config.conf
 
     :param login_res: -- tuple of two elements, where first - if login
     was successful, second - failure message  
     """
     print("Login failed: ", login_res[1])
-    print('Make sure secrets.json has the following format\n'
-        '{\n'
-        '    "username" : "<your username>",\n'
-        '    "password" : "<your password>"\n'
-        '}')
-
-
+    print('Make sure you specified you username and password in config.conf:\n'
+        '[AUTH]\n'
+        'username = <your username>\n'
+        'password = <your password>\n'
+        )
+    
 def request_with_login(func, *args, **kwargs):
     """
-    Performs a request with the added information for authentification.
+    Performs a request with the added information for authentication.
     If the request fails with 403, the function does a second login attempt
-    to generate new cookies. If after that the authentification still fails,
+    to generate new cookies. If after that the authentication still fails,
     the program exits, as the user need to fix the credentials.
 
-    AUTH_ENABLED is False, the reqular request is performed instead.
     :param func: -- function to perform the request, such as requests.get
-    :param args: -- fuction parameters
+    :param args: -- function parameters
     :param kwargs: -- function keyword parameters
     """
-    if not AUTH_ENABLED:
-        return func(*args, **kwargs, timeout=TIMEOUT)
-    if not exists("cookies.json"):
-        res = login()
-        if not res[0]:
-            print_login_failure(res)
-            exit(1)
-    with open("cookies.json") as f:
-        cookies = json.load(f)
+    global cookies
+
+    if cookies is None:
+        if not exists("cookies.json"):
+            res = login()
+            if not res[0]:
+                print_login_failure(res)
+                exit(1)
+        else:
+            with open("cookies.json") as f:
+                cookies = json.load(f)
 
     response = func(*args, **kwargs, cookies=cookies, timeout=TIMEOUT)
     
@@ -99,8 +93,6 @@ def request_with_login(func, *args, **kwargs):
         if not res[0]:
             print_login_failure(res)
             exit(1)
-        with open("cookies.json") as f:
-            cookies = json.load(f)
         response = func(*args, **kwargs, cookies=cookies, timeout=TIMEOUT)
     
     return response
@@ -128,10 +120,19 @@ def pause_all_seeding_torrents():
         with open(PAUSED_TORRENT_SAVE_FILE, "w") as file:
             json.dump(list(hashes), file)
 
+        hashes = set([torrent["hash"] for torrent in seeding_torrents])
+        if exists(PAUSED_TORRENT_SAVE_FILE):
+            with open(PAUSED_TORRENT_SAVE_FILE) as f:
+                previous_hashes = set(json.load(f))
+            hashes = hashes.union(previous_hashes)
+        with open(PAUSED_TORRENT_SAVE_FILE, "w") as file:
+            json.dump(list(hashes), file)
+
         if len(seeding_torrents):
             for torrent in seeding_torrents:
                 request_with_login(requests.post, f"{QB_URL}/api/v2/torrents/pause", data={"hashes": torrent["hash"]})
             print("Daily upload data usage limit reached, all seeding torrents paused")
+        return True
         return True
     except:
         return False  # qBittorrent is offline
@@ -140,6 +141,20 @@ def pause_all_seeding_torrents():
 def resume_all_paused_torrents():
     try:
         paused_torrents = request_with_login(requests.get, f"{QB_URL}/api/v2/torrents/info?filter=paused").json()
+        paused_hashes = set([torrent["hash"] for torrent in paused_torrents])
+        hashes = paused_hashes
+        if exists(PAUSED_TORRENT_SAVE_FILE):
+            with open(PAUSED_TORRENT_SAVE_FILE) as f:
+                seeding_hashes = set(json.load(f))
+            with open(PAUSED_TORRENT_SAVE_FILE,"w") as f:
+                f.write("[]")
+            preserved_hashed = paused_hashes.intersection(seeding_hashes)
+            hashes = preserved_hashed
+        
+        if len(hashes):
+            for hash in hashes:
+                request_with_login(requests.post, f"{QB_URL}/api/v2/torrents/resume", data={"hashes": hash})
+        return True
         paused_hashes = set([torrent["hash"] for torrent in paused_torrents])
         hashes = paused_hashes
         if exists(PAUSED_TORRENT_SAVE_FILE):
@@ -296,7 +311,63 @@ def reset_daily_usage():
             reset_job = schedule.every(CHECK_INTERVAL).seconds.do(reset_daily_usage).run()
 
 
+def load_config():
+    CONFIG_NAME = "config.conf"
+
+    config = configparser.ConfigParser()
+    
+    default_config = {
+        "UPLOAD_LIMIT":50, 
+        "QB_URL":"http://localhost:8080", 
+        "CHECK_INTERVAL":60, 
+        "RESET_TIME":"00:01", 
+        "TIMEOUT":10,
+    }
+
+    getint = config.getint
+    config_types = {
+        "UPLOAD_LIMIT": getint, 
+        "CHECK_INTERVAL":getint, 
+        "TIMEOUT":getint,
+    }
+
+    
+    default_config_auth = {
+        "username" : "",
+        "password" : "",
+    }
+
+    if not exists(CONFIG_NAME):
+        print(f"{CONFIG_NAME} not found, the default config file has been created.")
+        config["SETTINGS"] = default_config
+        config["AUTH"] = default_config_auth
+        with open(CONFIG_NAME, "w") as f:
+            config.write(f)
+
+    config.read(CONFIG_NAME)
+
+    error_str = "{} not found in " + CONFIG_NAME + ". Please" \
+                "add it to " + CONFIG_NAME + "or check the writing. " \
+                "Default value = {}"
+    for key in default_config:
+        key_lower = key.lower()
+        if key_lower not in config["SETTINGS"]:
+            raise ValueError(error_str.format(key, default_config[key]))
+        else:
+            if key in config_types:
+                type_conversion_func = config_types[key]
+                globals()[key] = type_conversion_func("SETTINGS", key_lower)        
+            else:
+                globals()[key] = config["SETTINGS"][key_lower]
+    for key in default_config_auth:
+        if key not in config["AUTH"]:
+            raise ValueError(error_str.format(key, default_config[key]))
+        else:
+            globals()[key] = config["AUTH"][key]
+
+
 if __name__ == "__main__":
+    load_config()
     check_previous_session_upload_data_usage()
     check_saved_torrents()
     


### PR DESCRIPTION
- All the config parameters were moved to config.conf. 
- AUTH_ENABLED was removed, as it wasn't necessary - qBittorrent accepts empty username/password when authetication is disabled.
- Update README.md with the config explanation, change the section on authentication and add a new one for running the script outside windows scheduler

Depends-on: https://github.com/Tetrax-10/qBittorrent-upload-limit-per-day/pull/4